### PR TITLE
make sure gandi-postboot is started after swap has been configured

### DIFF
--- a/systemd/system/gandi-bootstrap.service
+++ b/systemd/system/gandi-bootstrap.service
@@ -15,4 +15,5 @@ After=local-fs.target remote-fs.target
 Type=simple
 RemainAfterExit=no
 ExecStart=/etc/init.d/gandi-bootstrap start
+ExecStopPost=/etc/init.d/gandi-postboot start
 


### PR DESCRIPTION
this fixes a race with systemd when gandi-postboot is ran before init script has been extracted from swap