### PR TITLE
add scripts and dependencies to decompress LZ4 kernels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,11 @@ ifeq ($(OS),Linux)
 	install -d -m 0750 $(DESTDIR)/etc/auto.master.d
 	install -m 0640 autofs/auto.master.d/gandi.autofs $(DESTDIR)/etc/auto.master.d/
 	install -m 0750 autofs/auto.gandi $(DESTDIR)/etc/
+
+	install -d ${DESTDIR}/etc/kernel/postinst.d
+	install -m 0750 ./etc/kernel/postinst.d/gandi-decompress-kernel ${DESTDIR}/etc/kernel/postinst.d/
+	install -m 0750 ./decompress-kernel ${DESTDIR}/usr/share/gandi/
+	install -m 0750 ./extract-vmlinux ${DESTDIR}/usr/share/gandi/
 endif
 	
 	install -d -m 0755 $(DESTDIR)/etc/default

--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,10 @@ Depends: openssl,
  module-init-tools | kmod,
  python,
  acpid,
- acpi-support-base | acpi-support
+ acpi-support-base | acpi-support,
+ mktemp | coreutils,
+ binutils,
+ lz4 | liblz4-tool
 Recommends: gdisk
 Suggests: autofs
 Conflicts: gandi-hosting-agent, 

--- a/debian/postinst
+++ b/debian/postinst
@@ -53,6 +53,12 @@ autofs_handle_srv() {
 	return $?
 }
 
+decompress_lz4_kernel() {
+	for kernel in /boot/vmlinuz-*;
+		do /usr/share/gandi/decompress-kernel "$kernel";
+	done
+}
+
 case "$1" in
 	configure|upgrade)
 
@@ -188,6 +194,7 @@ case "$1" in
 			if [ `echo "${lsb_release}" | cut -d'.' -f1` -gt 8 ]; then
 				disable_udev_disk_rules
 			fi
+			decompress_lz4_kernel
 		fi
 
 		# Ubuntu bionic
@@ -195,6 +202,7 @@ case "$1" in
 			if [ `echo "${lsb_release}" | cut -d'.' -f1` -gt 17 ]; then
 				disable_udev_disk_rules
 			fi
+			decompress_lz4_kernel
 		fi
 
 		# the system uses autofs and customer rules handle /srv
@@ -253,6 +261,7 @@ case "$1" in
 		rm -rf /etc/gandi/plugins.d/10-config_sysctl
 
 		[ -d /var/gandi ] || mkdir /var/gandi
+
 	;;
 
 	abort-upgrade|abort-remove|abort-deconfigure)

--- a/decompress-kernel
+++ b/decompress-kernel
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+
+KERNEL_PATH="$1"
+
+LZ4_PATTERN=$(printf '\002!L\030')
+
+if grep -aq "${LZ4_PATTERN}" "${KERNEL_PATH}"; then
+	echo "Kernel is compressed with LZ4, decompressing ${KERNEL_PATH}" >&2
+	tmp_file=$(mktemp /tmp/raw-kernel-XXXX)
+	if [ $? -gt 0 ]; then
+		echo "Cannot create temporary file. Exiting...";
+		exit 1;
+	fi
+	trap "rm -f ${tmp_file}" 0 2
+	/usr/share/gandi/extract-vmlinux "${KERNEL_PATH}" > "${tmp_file}"
+
+	if ! readelf -h ${tmp_file} > /dev/null; then 
+		echo "Failed to decompress kernel. Exiting..." >&2
+		exit 1
+	fi
+	echo "Decompressed kernel from ${KERNEL_PATH}" >&2
+	echo "Replacing original file..." >&2
+	mv "${tmp_file}" "${KERNEL_PATH}"
+else
+	echo "Kernel is not compressed using LZ4. Exiting..." >&2
+fi

--- a/etc/kernel/postinst.d/gandi-decompress-kernel
+++ b/etc/kernel/postinst.d/gandi-decompress-kernel
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+KERNEL_PATH="$2"
+
+/usr/share/gandi/decompress-kernel "${KERNEL_PATH}"

--- a/extract-vmlinux
+++ b/extract-vmlinux
@@ -1,0 +1,64 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+# ----------------------------------------------------------------------
+# extract-vmlinux - Extract uncompressed vmlinux from a kernel image
+#
+# Inspired from extract-ikconfig
+# (c) 2009,2010 Dick Streefland <dick@streefland.net>
+#
+# (c) 2011      Corentin Chary <corentin.chary@gmail.com>
+#
+# ----------------------------------------------------------------------
+
+check_vmlinux()
+{
+	# Use readelf to check if it's a valid ELF
+	# TODO: find a better to way to check that it's really vmlinux
+	#       and not just an elf
+	readelf -h $1 > /dev/null 2>&1 || return 1
+
+	cat $1
+	exit 0
+}
+
+try_decompress()
+{
+	# The obscure use of the "tr" filter is to work around older versions of
+	# "grep" that report the byte offset of the line instead of the pattern.
+
+	# Try to find the header ($1) and decompress from here
+	for	pos in `tr "$1\n$2" "\n$2=" < "$img" | grep -abo "^$2"`
+	do
+		pos=${pos%%:*}
+		tail -c+$pos "$img" | $3 > $tmp 2> /dev/null
+		check_vmlinux $tmp
+	done
+}
+
+# Check invocation:
+me=${0##*/}
+img=$1
+if	[ $# -ne 1 -o ! -s "$img" ]
+then
+	echo "Usage: $me <kernel-image>" >&2
+	exit 2
+fi
+
+# Prepare temp files:
+tmp=$(mktemp /tmp/vmlinux-XXX)
+trap "rm -f $tmp" 0
+
+# That didn't work, so retry after decompression.
+try_decompress '\037\213\010' xy    gunzip
+try_decompress '\3757zXZ\000' abcde unxz
+try_decompress 'BZh'          xy    bunzip2
+try_decompress '\135\0\0\0'   xxx   unlzma
+try_decompress '\211\114\132' xy    'lzop -d'
+try_decompress '\002!L\030'   xxx   'lz4 -d'
+try_decompress '(\265/\375'   xxx   unzstd
+
+# Finally check for uncompressed images or objects:
+check_vmlinux $img
+
+# Bail out:
+echo "$me: Cannot find vmlinux." >&2


### PR DESCRIPTION
This MR aims to enable both a kernel postinstall and a package postinstall hooks to decompress the kernel if it is compressed using LZ4 on a debian / ubuntu based system.

This is related to #12 