### PR TITLE
manage_iface: Add support for sandboxed systemd-udev

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -106,6 +106,10 @@ case "$1" in
 					systemctl enable gandi-${elt}.service || true
 				fi
 			done 
+
+			if [ -e "/usr/share/gandi/systemd/gandi-dhclient@.service" ]; then
+				ln -sf "/usr/share/gandi/systemd/gandi-dhclient@.service" "/lib/systemd/system/" || true
+			fi
 		fi
 
 		# config service

--- a/rpm/gandi-hosting-vm2.spec
+++ b/rpm/gandi-hosting-vm2.spec
@@ -97,7 +97,7 @@ install -m 0644 %{sourcedir}/usr/lib/sysctl.d/90-gandi.conf \
 # only in case of uninstall of package.
 SYSTEMD=$(which systemd)
 if [ "$1" -eq 0 ]; then
-    for elt in mount config bootstrap postboot; do
+    for elt in mount config bootstrap postboot dhclient@; do
         if [ -e $SYSTEMD ]; then
             rm -f "/etc/systemd/system/default.target.wants/gandi-$elt"
             rm -f "/lib/systemd/system/gandi-$elt"
@@ -180,6 +180,11 @@ if [ -e $SYSTEMD ]; then
                    /etc/systemd/system/default.target.wants/ || true
         fi
     done
+    srcfile="/usr/share/gandi/systemd/gandi-dhclient@.service"
+    if [ -e "$srcfile" ]; then
+        ln -sf "$srcfile" /lib/systemd/system || true
+        ln -sf "$srcfile" /usr/lib/systemd/system || true
+    fi
 else
     if [ -x /sbin/chkconfig ]; then
         for elt in config mount postboot bootstrap; do
@@ -263,6 +268,7 @@ rm -rf $RPM_BUILD_ROOT
 /usr/share/gandi/systemd/gandi-mount.service
 /usr/share/gandi/systemd/gandi-postboot.service
 /usr/share/gandi/systemd/gandi-bootstrap.service
+/usr/share/gandi/systemd/gandi-dhclient@.service
 
 %changelog 
 * Fri Sep 19 2008 Nicolas Chipaux <aegiap@gandi.net> 1.0.0-1474-1gnd

--- a/systemd/system/gandi-dhclient@.service
+++ b/systemd/system/gandi-dhclient@.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=dhclient on %I
+Wants=network.target
+Before=network.target
+BindsTo=sys-subsystem-net-devices-%i.device
+After=sys-subsystem-net-devices-%i.device
+
+[Service]
+Type=forking
+ExecStart=/sbin/dhclient -4 -v -pf /run/dhclient.%I.pid -lf /var/lib/dhcp/dhclient.%I.leases %I
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
`systemd-udev` limits the actions a udev script can do by putting
it in a sandbox. This removes the possibility for the udev hook
to call `dhclient`.

In order to comply with `systemd-udev` requirements a `dhclient` generic
service is created that can be started by the udev hook.
The service is bound to the device so that the service is automatically
stopped if the interface is removed.

One notable change from the previous in-script mechanism is the use of a
long-lived `dhclient` instead of a one-shot instance.