### PR TITLE
Fix /etc/fstab line management for / when using UUIDs

### DIFF
--- a/gandi-config/plugins.d/02-config_system_file
+++ b/gandi-config/plugins.d/02-config_system_file
@@ -47,7 +47,11 @@ if [ ! -d /proc/xen ]; then
 fi
 
 new_value=$(blkid -s UUID -o value "/dev/${correct_root_device}")
-[ ! -z "${new_value}" ] || new_value="/dev/${correct_root_device}"
+if [ -z "${new_value}" ]; then
+    new_value="/dev/${correct_root_device}"
+else
+    new_value="UUID=${new_value}"
+fi
 
 if [ ! -e "$config_file" ]; then
     cat > "${config_file}" << EOT


### PR DESCRIPTION
UUIDs in /etc/fstab can be used with "UUID=<uuid>" to designate a device but the script was missing "UUID=" part when using UUIDs.