### PR TITLE
Add sshdkeygen systemd service

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -40,6 +40,7 @@ Description: scripts for virtual machine on Gandi IaaS
   - gandi-mount  : if virtual disk is not detected and already
   mounted, this service start a udev call to re-attach all 
   available unmounted virtual disks.
+  - sshdkeygen: Ensure the host keys exist before starting sshd
  .
  In case of GPT partition on disk, you should install gdisk to
  handle the partitions.

--- a/debian/postinst
+++ b/debian/postinst
@@ -96,7 +96,7 @@ case "$1" in
 				syswant=/etc/systemd/system/default.target.wants
 			fi
 
-			for elt in mount config postboot bootstrap; do 
+			for elt in mount config postboot bootstrap sshdkeygen; do
 				rm -f "/lib/systemd/system/gandi-${elt}.service" || true
 				rm -f "$syswant/gandi-${elt}.service" || true
 

--- a/debian/prerm
+++ b/debian/prerm
@@ -5,7 +5,7 @@ set -e
 
 case "$1" in
 	remove|deconfigure)
-		for elt in config mount postboot bootstrap; do
+		for elt in config mount postboot bootstrap sshdkeygen; do
 			systemctl disable gandi-${elt}.service
 		done
 		;;

--- a/systemd/system/gandi-sshdkeygen.service
+++ b/systemd/system/gandi-sshdkeygen.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Ensure host ssh keys exist before starting sshd
+Before=ssh.service
+ConditionPathExists=!/etc/ssh/ssh_host_dsa_key
+ConditionPathExists=!/etc/ssh/ssh_host_dsa_key.pub
+ConditionPathExists=!/etc/ssh/ssh_host_ecdsa_key
+ConditionPathExists=!/etc/ssh/ssh_host_ecdsa_key.pub
+ConditionPathExists=!/etc/ssh/ssh_host_ed25519_key
+ConditionPathExists=!/etc/ssh/ssh_host_ed25519_key.pub
+ConditionPathExists=!/etc/ssh/ssh_host_rsa_key
+ConditionPathExists=!/etc/ssh/ssh_host_rsa_key.pub
+
+[Service]
+ExecStart=/usr/bin/ssh-keygen -A
+Type=oneshot
+RemainAfterExit=yes
+
+[Install]
+WantedBy=ssh.service


### PR DESCRIPTION
This is heavily inspired by Archlinux' sshdgenkeys. The goal is to ensure host keys exist before the sshd service is started, creating those keys with "ssh-keygen -A" if required.