### PR TITLE
Fix rpm build failing

### DIFF
--- a/rpm/gandi-hosting-vm2.spec
+++ b/rpm/gandi-hosting-vm2.spec
@@ -269,6 +269,7 @@ rm -rf $RPM_BUILD_ROOT
 /usr/share/gandi/systemd/gandi-postboot.service
 /usr/share/gandi/systemd/gandi-bootstrap.service
 /usr/share/gandi/systemd/gandi-dhclient@.service
+/usr/share/gandi/systemd/gandi-sshdkeygen.service
 
 %changelog 
 * Fri Sep 19 2008 Nicolas Chipaux <aegiap@gandi.net> 1.0.0-1474-1gnd


### PR DESCRIPTION
The newly added `gandi-sshdkeygen.service` service file was not in the rpm spec file, causing the rpm build to fail.