### PR TITLE
Decompress ZSTD kernels

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,8 @@ Depends: openssl,
  acpi-support-base | acpi-support,
  mktemp | coreutils,
  binutils,
- lz4 | liblz4-tool
+ lz4 | liblz4-tool,
+ zstd
 Recommends: gdisk
 Suggests: autofs
 Conflicts: gandi-hosting-agent, 

--- a/decompress-kernel
+++ b/decompress-kernel
@@ -4,9 +4,10 @@
 KERNEL_PATH="$1"
 
 LZ4_PATTERN=$(printf '\002!L\030')
+ZSTD_PATTERN=$(printf '(\265/\375')
 
-if grep -aq "${LZ4_PATTERN}" "${KERNEL_PATH}"; then
-	echo "Kernel is compressed with LZ4, decompressing ${KERNEL_PATH}" >&2
+if grep -aq "${LZ4_PATTERN}\|${ZSTD_PATTERN}" "${KERNEL_PATH}"; then
+	echo "Kernel is compressed with LZ4 or Zstandard, decompressing ${KERNEL_PATH}" >&2
 	tmp_file=$(mktemp /tmp/raw-kernel-XXXX)
 	if [ $? -gt 0 ]; then
 		echo "Cannot create temporary file. Exiting...";
@@ -23,5 +24,5 @@ if grep -aq "${LZ4_PATTERN}" "${KERNEL_PATH}"; then
 	echo "Replacing original file..." >&2
 	mv "${tmp_file}" "${KERNEL_PATH}"
 else
-	echo "Kernel is not compressed using LZ4. Exiting..." >&2
+	echo "Kernel is not compressed using LZ4 nor Zstandard. Exiting..." >&2
 fi


### PR DESCRIPTION
We need to decompress zstd-compressed kernels on post-install instead of doing it only for lz4, to handle ubuntu 22.04